### PR TITLE
Reorder the tasks so secret variables are present

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,15 +74,6 @@
     mode: '0755'
   notify: [ 'Restart snmpd' ]
 
-- name: Configure snmpd service
-  template:
-    src: 'etc/snmp/snmpd.conf.j2'
-    dest: '/etc/snmp/snmpd.conf'
-    owner: 'root'
-    group: 'root'
-    mode: '0600'
-  notify: [ 'Restart snmpd' ]
-
 - name: Configure local SNMP credentials
   template:
     src: 'etc/snmp/snmp.local.conf.j2'
@@ -118,6 +109,15 @@
   run_once: True
   no_log: True
   when: snmpd_account|d() and snmpd_account
+
+- name: Configure snmpd service
+  template:
+    src: 'etc/snmp/snmpd.conf.j2'
+    dest: '/etc/snmp/snmpd.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
+  notify: [ 'Restart snmpd' ]
 
 - name: Configure SNMPv3 credentials
   include: configure_snmpv3_credentials.yml

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -8,6 +8,7 @@ sysContact    {{ snmpd_sys_contact }}
 
 sysServices   72
 
+{% if snmpd_account|d() and snmpd_account %}
 {% if snmpd_register_version|d() and not snmpd_register_version.stdout %}
 rwuser        {{ snmpd_account_admin_username }}   priv
 {% endif %}
@@ -17,6 +18,7 @@ rouser        {{ snmpd_account_local_username }}   priv
 iquerySecName {{ snmpd_account_agent_username }}
 agentSecName  {{ snmpd_account_agent_username }}
 
+{% endif %}
 master agentx
 
 {% if snmpd_load|d() and snmpd_load %}


### PR DESCRIPTION
Role uses a shared username / password combination on all managed hosts,
but because at the moment Ansible fails when creating the same file
multiple times, they need to be created only once. Therefore a separate
'set_fact' task is used.

This change reorders the task so that variables are populated earlier
and are available for '/etc/snmp/snmpd.conf' template.