### PR TITLE
Allow users to have a custom snmpd.conf.j2.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,7 +132,7 @@
 
 - name: Configure snmpd service
   template:
-    src: 'etc/snmp/snmpd.conf.j2'
+    src: '{{ lookup("template_src", "etc/snmp/snmpd.conf.j2") }}'
     dest: '/etc/snmp/snmpd.conf'
     owner: 'root'
     group: 'root'


### PR DESCRIPTION
The task "Configure snmpd service" now uses the lookup("template_src")
module to find the snmpd.conf.j2 template instead, to allow the user
to make a custom snmpd.conf.j2 template by setting "template-paths"
in .debops.cfg.