### PR TITLE
debops.snmpd: duplicated snmpd_download_mibs install with one hardcoded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     state: 'present'
     install_recommends: False
   with_flattened:
-    - [ 'snmp', 'snmpd', 'snmp-mibs-downloader' ]
+    - [ 'snmp', 'snmpd' ]
     - [ '{{ "snmp-mibs-downloader" if snmpd_download_mibs else [] }}' ]
     - [ '{{ "lldpd" if snmpd_lldpd else [] }}' ]
     - [ '{{ "lm-sensors" if (ansible_virtualization_role is undefined or ansible_virtualization_role not in [ "guest" ]) else [] }}' ]


### PR DESCRIPTION
A boolean is available to choose if snmp-mibs-downloader is installed.
Remove this package from previous list where it is hardcoded.