### PR TITLE
Debian stretch+ smnpd daemon switched to new user and group: Debian-s…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+v0.1.2
+------
+
+*Unreleased*
+
+Fixed
+~~~~~
+
+- The ownership of the net-snmp snmpd daemon changed from user snmp to Debian-snmp
+  on Debian stretch and later. This transtition helps with conflicting users
+  on LDAP systems. Fixes `Debian Bug #794647`_. [prahal]
+
+.. _Debian Bug #794647: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794647
+
 v0.1.1
 ------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,11 @@
 
 - name: Allow 'snmp' user access to /proc if needed
   user:
-    name: 'snmp'
+    name: '{{ "snmp"
+              if (ansible_local|d() and ansible_local.core|d() and
+                  (ansible_local.core.distribution in [ "Ubuntu" ] or
+                   ansible_local.core.distribution_release in [ "wheezy", "jessie" ]))
+              else "Debian-snmp" }}'
     groups: '{{ snmpd_proc_hidepid_group }}'
     append: True
   when: snmpd_proc_hidepid | bool

--- a/templates/etc/default/snmpd.j2
+++ b/templates/etc/default/snmpd.j2
@@ -18,7 +18,13 @@ export MIBS=
 SNMPDRUN=yes
 
 # snmpd options (use syslog, close stdin/out/err).
+{% if (ansible_local|d() and ansible_local.core|d() and
+       (ansible_local.core.distribution in [ 'Ubuntu' ] or
+        ansible_local.core.distribution_release in [ 'wheezy', 'jessie' ])) %}
 SNMPDOPTS='{{ snmpd_logging_options }} -Lf /dev/null -u snmp -g snmp -I -smux,mteTrigger,mteTriggerConf -p /run/snmpd.pid'
+{% else %}
+SNMPDOPTS='{{ snmpd_logging_options }} -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -p /run/snmpd.pid'
+{% endif %}
 
 {% if ansible_distribution_release in [ 'wheezy', 'precise', 'trusty' ] %}
 # snmptrapd control (yes means start daemon).  As of net-snmp version


### PR DESCRIPTION
…nmp.

net-snmp 5.7.3+dfsg-1.1 changed the snmpd user from "snmp" to "Debian-snmp".
This was done to help LDAP handling per the changelog entry.
Ubuntu halted at 5.7.3+dfsg-1ubuntu4 (the one before this change) and is
still as of yakkety.

---

Ubuntu has no packages with the changes (thus I left the blacklisting the older releases list fro when this day come ; they did not include the "non-maintainer" uploads from 2016).

To keep the logic bare simple I set Debian-snmp last.
