### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.2
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.2
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+*Unreleased*
+
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 v0.1.2
 ------
 
@@ -64,4 +71,3 @@ v0.1.0
 
 - Make sure that variables which define SNMP passwords are set on all hosts
   during Ansible playbook run, since the old issue has been resolved. [drybjed]
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Install and configure SNMP service'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.8.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   register: snmpd_register_version
   changed_when: False
   failed_when: False
-  always_run: True
+  check_mode: no
 
 - name: Install required packages
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   register: snmpd_register_version
   changed_when: False
   failed_when: False
-  check_mode: no
+  check_mode: False
 
 - name: Install required packages
   apt:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.